### PR TITLE
Add ->set method

### DIFF
--- a/t/set.t
+++ b/t/set.t
@@ -1,0 +1,28 @@
+use strict;
+use Test::More;
+use Hash::MultiValue;
+
+my @l = qw( foo a bar baz foo b bar quux );
+
+my $hash = Hash::MultiValue->new( @l );
+
+$hash->set(foo => 1 .. 3);
+is_deeply [ $hash->flatten ], [ qw( foo 1 bar baz foo 2 bar quux foo 3 ) ], 'more items than before';
+is $hash->{'foo'}, 3;
+
+$hash->add(bar => 'qux');
+$hash->set(bar => 'a' .. 'c');
+is_deeply [ $hash->flatten ], [ qw( foo 1 bar a foo 2 bar b foo 3 bar c ) ], 'exactly as many items as before';
+is $hash->{'bar'}, 'c';
+
+$hash->set(foo => qw(x y));
+is_deeply [ $hash->flatten ], [ qw( foo x bar a foo y bar b bar c ) ], 'fewer items than before';
+is $hash->{'foo'}, 'y';
+
+$hash->set('bar');
+is_deeply [ $hash->flatten ], [ qw( foo x foo y ) ], 'no items';
+is $hash->{'bar'}, undef;
+
+isa_ok $hash, 'Hash::MultiValue';
+
+done_testing;


### PR DESCRIPTION
From the POD:

> ```
> $hash->set($key [, $value ... ]);
> ```
> 
> Changes the stored value(s) of the given `$key`. This removes or adds pairs as necessary to store the new list but otherwise preserves order of existing pairs. `$hash->{$key}` is updated to point to the last value.

This is a generalisation of the `remove` method. It’s significantly more complex by necessity, but I think the code came out fairly clear and readable.

Tests included.

(I opted to include an optimisation that would have made the very plain `remove` much more complex, but made little difference here: if the pairs that need to be removed are in the far back of the K/V list, the unaffected part of the K/V arrays at the front won’t be re-assigned (cf. line 113).)
