### PR TITLE
Re-apply set method optimisation that was lost in 0.11

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for Perl extension Hash::MultiValue
 
+        - Reapply set method optimisation that was lost in 0.11
+
 0.11  Sun Feb 12 13:04:54 PST 2012
         - Fix segfaulting splice invocation on perls < 5.8.7
         - Fix uninitialized warning on older perls

--- a/lib/Hash/MultiValue.pm
+++ b/lib/Hash/MultiValue.pm
@@ -114,14 +114,10 @@ sub set {
             push @keep, $i;
         }
 
-        # this used to be written as
-        #   splice @$_, $start, 0+@$_, @$_[@keep]
-        # however older perls crash on attempts to splice-replace a subscript
-        # of the array currently being splice()d
-        #
-        # I can not seem to find a relevant RT or perldelta entry, but this
-        # seems to have been fixed in 5.8.7
-        @$_ = @$_[0 .. $start-1, @keep] for ($k, $v);
+        # the @{[]} here is necessary because perls < 5.8.7 segfault
+        # when directly splicing in a subscript from the same array
+        # (there does not seem to be a relevant RT or perldelta entry)
+        splice @$_, $start, 0+@$_, @{[ @$_[@keep] ]} for $k, $v;
     }
 
     if (@_) {


### PR DESCRIPTION
The change @ribasushi made to fix the crash on perls < 5.8.7 means that the start of the array gets copied even though it is invariant. I fixed the crash a different way, switching back to `splice`, but using `@{[]}` to force creation of a temporary array so that the source array is different from the destination array. I have confirmed that this fix prevents the segfault on 5.8.5, which otherwise occurs as reported. I will check earlier perls if desired.
