### PR TITLE
Add Storable serialization support

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for Perl extension Hash::MultiValue
 
+        - Add support for Storable serialization
+
 0.11  Sun Feb 12 13:04:54 PST 2012
         - Fix segfaulting splice invocation on perls < 5.8.7
         - Fix uninitialized warning on older perls

--- a/lib/Hash/MultiValue.pm
+++ b/lib/Hash/MultiValue.pm
@@ -258,6 +258,22 @@ sub as_hashref_multi {
 
 sub multi { $_[0]->as_hashref_multi }
 
+sub STORABLE_freeze {
+    my $self = shift;
+    my $this = refaddr $self;
+    return '', $keys{$this}, $values{$this};
+}
+
+sub STORABLE_thaw {
+    my $self = shift;
+    my ($is_cloning, $serialised, $k, $v) = @_;
+    my $this = refaddr $self;
+    $keys  {$this} = $k;
+    $values{$this} = $v;
+    @{$self}{@$k} = @$v;
+    return $self;
+}
+
 1;
 __END__
 

--- a/t/storable.t
+++ b/t/storable.t
@@ -1,0 +1,24 @@
+use strict;
+use Test::More;
+use Hash::MultiValue;
+use Storable qw(freeze thaw dclone);
+
+my $l = [ qw( foo a bar baz foo b bar quux ) ];
+
+my $hash = Hash::MultiValue->new( @$l );
+
+is_deeply [ $hash->flatten ], $l, 'flattening works';
+
+my $frozen = freeze $hash;
+undef $hash;
+$hash = thaw $frozen;
+is_deeply [ $hash->flatten ], $l, '... even after deserialisation';
+
+my $clone = dclone $hash;
+is_deeply [ $clone->flatten ], $l, '... and cloning';
+
+$clone->remove('foo');
+my ($n_hash, $n_clone) = map scalar @{[$_->flatten]}, $hash, $clone;
+ok $n_hash > $n_clone, '... which makes independent objects';
+
+done_testing;


### PR DESCRIPTION
This covers what @wchristian requested in #4.

I’ve done the tests a little differently, with no real IPC, because I don’t know how to do that reliably portably. I changed the literal `perl` call in his backticks to a `$^X` and switched to using a proper temporary file, but I don’t know to be sure to pass down the right `@INC` to the invoked `perl` if that has been rigged for the tests during build time. I thought of just forking and pushing the frozen object to the child process through a pipe but hell if I know how to make that portable onto Windows.

In the end I decided that if the test fails as expected before patching H::MV and passes for the right reason afterwards, even if it doesn’t involve real IPC, that’s a good enough test for me.

I hope it is.
